### PR TITLE
fix: Updated `adata.Load` and `adata.Save` function call to add `conda_env` parameter

### DIFF
--- a/R/Anndata.R
+++ b/R/Anndata.R
@@ -158,7 +158,7 @@ scv.tl.velocity_graph(adata)
 
   # Save adata if save.adata is provided
   if (!is.null(save.adata)) {
-    adata.Save(save.adata)
+    adata.Save(save.adata, conda_env = conda_env)
   }
 
   invisible(NULL)
@@ -203,7 +203,7 @@ adata.obs['", current_col, "'] = ", py_var_name, "
 
   # Save adata if save.adata is provided
   if (!is.null(save.adata)) {
-    adata.Save(save.adata)
+    adata.Save(save.adata, conda_env = conda_env)
   }
 
   invisible(NULL)
@@ -229,7 +229,7 @@ adata = sc.read_loom('{loompath}')
 
   # Save adata if save.adata is provided
   if (!is.null(save.adata)) {
-    adata.Save(save.adata)
+    adata.Save(save.adata, conda_env = conda_env)
   }
 
   invisible(NULL)
@@ -254,7 +254,7 @@ Seu2Adata <- function(
 
   # Save adata if save.adata is provided
   if (!is.null(save.adata)) {
-    adata.Save(save.adata)
+    adata.Save(save.adata, conda_env = conda_env)
   }
 
   invisible(NULL)

--- a/R/Anndata.R
+++ b/R/Anndata.R
@@ -133,7 +133,7 @@ adata.AddDR <- function(
 
   # Load adata if load.adata is provided
   if (!is.null(load.adata)) {
-    adata.Load(load.adata)
+    adata.Load(load.adata, conda_env = conda_env)
   }
 
   # Export all the dr to the adata object
@@ -181,7 +181,7 @@ adata.AddMetadata <- function(
 
   # Load adata if load.adata is provided
   if (!is.null(load.adata)) {
-    adata.Load(load.adata)
+    adata.Load(load.adata, conda_env = conda_env)
   }
 
   # Check if the specified columns exist in the Seurat metadata

--- a/R/Cellrank.R
+++ b/R/Cellrank.R
@@ -47,7 +47,7 @@ Cellrank.Compute <- function(
 
   # Load adata if load.adata is provided
   if (!is.null(load.adata)) {
-    adata.Load(load.adata)
+    adata.Load(load.adata, conda_env = conda_env)
   }
 
   # Pass the time_key parameter to Python
@@ -108,7 +108,7 @@ Cellrank.Plot <- function(
 
   # Load adata if load.adata is provided
   if (!is.null(load.adata)) {
-    adata.Load(load.adata)
+    adata.Load(load.adata, conda_env = conda_env)
   }
 
   # Construct the function call

--- a/R/scVelo.R
+++ b/R/scVelo.R
@@ -506,7 +506,7 @@ scVelo.Plot <- function(
 
   # Load adata if load.adata is provided
   if (!is.null(load.adata)) {
-    adata.Load(load.adata)
+    adata.Load(load.adata, conda_env = conda_env)
   }
 
   # Determine the scv plotting function


### PR DESCRIPTION
`conda_env` should be passed to `adata.Load` and `adata.Save`, otherwise environment creation will still be called when using custom environment.