### PR TITLE
keep factor levels when split in DotPlot.R

### DIFF
--- a/R/DotPlot.R
+++ b/R/DotPlot.R
@@ -255,11 +255,11 @@ DotPlot2 <- function(
   }
 
   if (flip) {
-    ToPlot$group <- factor(ToPlot$group, levels = rev(unique(ToPlot$group)))
-    ToPlot$Var1 <- factor(ToPlot$Var1, levels = unique(ToPlot$Var1))
+    ToPlot$group <- factor(ToPlot$group, levels = rev(levels(ToPlot$group)))
+    ToPlot$Var1 <- factor(ToPlot$Var1, levels = levels(ToPlot$Var1))
   } else {
-    ToPlot$group <- factor(ToPlot$group, levels = unique(ToPlot$group))
-    ToPlot$Var1 <- factor(ToPlot$Var1, levels = rev(unique(ToPlot$Var1)))
+    ToPlot$group <- factor(ToPlot$group, levels = levels(ToPlot$group))
+    ToPlot$Var1 <- factor(ToPlot$Var1, levels = rev(levels(ToPlot$Var1)))
   }
 
   value_range <- range(ToPlot$zscore)
@@ -424,7 +424,7 @@ DotPlot2 <- function(
   if (!is.null(split.by) && split.by.method == "annotation") {
     library(cowplot)
 
-    # Create annotation bar data 
+    # Create annotation bar data
     annotation_data <- ToPlot %>%
       dplyr::select(group, split, nudge) %>%
       dplyr::distinct() %>%


### PR DESCRIPTION
Hi:

when split plot in DotPlot2, the levels of group will be changed according to charactor levels rather than use-defined levels. Therefore, I change the code as follows:

```
#beofre
ToPlot$group <- factor(ToPlot$group, levels = unique(ToPlot$group))

#after
ToPlot$group <- factor(ToPlot$group, levels = levels(ToPlot$group))
```

####before
<img width="671" height="572" alt="image" src="https://github.com/user-attachments/assets/7e467580-554a-4af9-a8d1-62c278c0bbd8" />


####after

<img width="692" height="686" alt="image" src="https://github.com/user-attachments/assets/024d7705-4252-423b-95cf-5daccc04f288" />




You can test the code according to the following code:

```
Idents(pbmc) = "cluster"

levels(Idents(pbmc))
#[1] "B cell"       "CD4 T Memory" "CD4 T Naive"  "CD8 T cell"   "DC"           "Mono CD14"
#[7] "Mono FCGR3A"  "NK cell"      "Platelet"

genes <- VariableFeatures(pbmc)[1:10]

#before change
DotPlot2(pbmc, features = genes, group.by = "cluster", split.by = "orig.ident", split.by.method = "color", show_grid = FALSE)

#change levels with use-defined levels.

pbmc$cluster = factor(pbmc$cluster,
                      levels = c("Platelet", "DC", "Mono CD14", "Mono FCGR3A", "B cell", "CD4 T Memory", "CD4 T Naive", "CD8 T cell", "NK cell")
                      )

Idents(pbmc) = "cluster"

levels(Idents(pbmc))

DotPlot2(pbmc, features = genes, group.by = "cluster", split.by = "orig.ident", split.by.method = "color", show_grid = FALSE
)

```








